### PR TITLE
Added few projects and changed section names

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,3 @@ Missing something awesome? Anyone is welcome to [submit projects to this list](h
 * [ModelOriented/MAIR](https://github.com/ModelOriented/MAIR): Monitoring impact of AI regulations.
 
 * Survival Analysis Reproducible ML - [Kaggle-Titanic-DVC](https://dagshub.com/kingabzpro/kaggle-titanic-dvc)
-
-* OpenVaccine Covid-19 Vaccine Prediction - [mRNA Vaccine Degradation Prediction](https://dagshub.com/kingabzpro/mRNA-Vaccine-Degradation-Prediction)
-
-* Pretrained Discord Chatbot - [DailoGPT-Rick](https://dagshub.com/kingabzpro/DailoGPT-RickBot)

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,26 @@ Missing something awesome? Anyone is welcome to [submit projects to this list](h
 ## Tutorials
 * [DVC Streamlit Example](https://github.com/sicara/dvc-streamlit-example): Build a custom web UI with DVC and Streamlit for visually tracking & comparing model performance during R&D (adapted from [TensorFlow's transfer learning tutorial](https://www.tensorflow.org/tutorials/images/transfer_learning)).
 
+* [DVC Pipelines and Experiments Tutorial](https://github.com/dmesquita/dvc_pipelines_and_experiments_tutorial)
+
+* [CD4ML Example ](https://github.com/sbalnojan/cd4ml-example)
+
+### Iterative
+
+* [Example-get-started](https://github.com/iterative/example-get-started)
+
+* [DVC-Checkpoints-MNIST](https://github.com/iterative/dvc-checkpoints-mnist)
+
+* [Example-DVC-Experiments](https://github.com/iterative/example-dvc-experiments)
+
+* [DVC-Learn-Project](https://github.com/iterative/dvc-learn-project)
+
 ## Real-world Projects
 * [LensKit/lk-demo-experiment](https://github.com/lenskit/lk-demo-experiment): Demo DVC experiment [pipeline (DAG)](https://dvc.org/doc/user-guide/glossary#pipeline-DAG) using multiple public datasets, preprocessing & training, and Jupyter notebooks.
 * [ModelOriented/MAIR](https://github.com/ModelOriented/MAIR): Monitoring impact of AI regulations.
+
+* Survival Analysis Reproducible ML - [Kaggle-Titanic-DVC](https://dagshub.com/kingabzpro/kaggle-titanic-dvc)
+
+* OpenVaccine Covid-19 Vaccine Prediction - [mRNA Vaccine Degradation Prediction](https://dagshub.com/kingabzpro/mRNA-Vaccine-Degradation-Prediction)
+
+* Pretrained Discord Chatbot - [DailoGPT-Rick](https://dagshub.com/kingabzpro/DailoGPT-RickBot)

--- a/readme.md
+++ b/readme.md
@@ -15,23 +15,16 @@ Missing something awesome? Anyone is welcome to [submit projects to this list](h
 
 ## Tutorials
 * [DVC Streamlit Example](https://github.com/sicara/dvc-streamlit-example): Build a custom web UI with DVC and Streamlit for visually tracking & comparing model performance during R&D (adapted from [TensorFlow's transfer learning tutorial](https://www.tensorflow.org/tutorials/images/transfer_learning)).
-
-* [DVC Pipelines and Experiments Tutorial](https://github.com/dmesquita/dvc_pipelines_and_experiments_tutorial)
-
-* [CD4ML Example ](https://github.com/sbalnojan/cd4ml-example)
+* [DVC Pipelines and Experiments Tutorial](https://github.com/dmesquita/dvc_pipelines_and_experiments_tutorial): Build maintainable Machine Learning pipelines using DVC.
+* [CD4ML Example](https://github.com/sbalnojan/cd4ml-example): Example DVC setup with AWS S3 & GitLab.
 
 ### Iterative
-
-* [Example-get-started](https://github.com/iterative/example-get-started)
-
-* [DVC-Checkpoints-MNIST](https://github.com/iterative/dvc-checkpoints-mnist)
-
-* [Example-DVC-Experiments](https://github.com/iterative/example-dvc-experiments)
-
-* [DVC-Learn-Project](https://github.com/iterative/dvc-learn-project)
+* [Example-get-started](https://github.com/iterative/example-get-started): Train a `sklearn` random forest classifier for StackOverflow question tagging.
+* [Example-DVC-experiments](https://github.com/iterative/example-dvc-experiments): Train a Tensorflow CNN classifier for Fashion-MNIST data; used in https://dvc.org/doc/start/experiments.
+* [Example-versioning](https://github.com/iterative/example-versioning): Used in https://dvc.org/doc/use-cases/versioning-data-and-model-files/tutorial.
+* [DVC-Checkpoints-MNIST](https://github.com/iterative/dvc-checkpoints-mnist): A showcase for different ways to use the checkpoints. Train a PyTorch classifier on a CSV MNIST dataset.
 
 ## Real-world Projects
 * [LensKit/lk-demo-experiment](https://github.com/lenskit/lk-demo-experiment): Demo DVC experiment [pipeline (DAG)](https://dvc.org/doc/user-guide/glossary#pipeline-DAG) using multiple public datasets, preprocessing & training, and Jupyter notebooks.
-* [ModelOriented/MAIR](https://github.com/ModelOriented/MAIR): Monitoring impact of AI regulations.
-
-* Survival Analysis Reproducible ML - [Kaggle-Titanic-DVC](https://dagshub.com/kingabzpro/kaggle-titanic-dvc)
+* [ModelOriented/MAIR](https://github.com/ModelOriented/MAIR): Monitoring impact of AI regulations with a DVC pipeline.
+* [Kaggle-Titanic-DVC](https://dagshub.com/kingabzpro/kaggle-titanic-dvc): Survival analysis DVC experiment.


### PR DESCRIPTION
Hello DVC team,

I think making section names not base on data type, but base on field genre would be good idea. 

- [X] Added few projects.

- [X] Changed section names

Also please considering to change subsection names -> only DVC, DVC+CML, only CML 
Imho it looks like a little bit complicated 🤞