### PR TITLE
Add ZnTrack

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ Missing something awesome? Anyone is welcome to [submit projects to this list](h
 * [nvim-dvc](https://github.com/gennaro-tedesco/nvim-dvc): Neovim plugin for DVC.
 * [COVID Genomics/Airflow-DVC](https://github.com/covid-genomics/airflow-dvc): Airflow extension for DVC.
 * [COVID Genomics/dvc-fs](https://github.com/covid-genomics/dvc-fs): High-level abstraction for DVC file manipulation (listing & I/O) with basic support for [PyFilesystem2](https://github.com/PyFilesystem/pyfilesystem2).
-* [ZnTrack](https://github.com/zincware/ZnTrack): Object-Relational Mapping for https://dvc.org in Python.
+* [ZnTrack](https://github.com/zincware/ZnTrack): Create, visualize, run & benchmark DVC pipelines in Python & Jupyter notebooks.
 
 ## Tutorials
 * [DVC Streamlit Example](https://github.com/sicara/dvc-streamlit-example): Build a custom web UI with DVC and Streamlit for visually tracking & comparing model performance during R&D (adapted from [TensorFlow's transfer learning tutorial](https://www.tensorflow.org/tutorials/images/transfer_learning)).

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Missing something awesome? Anyone is welcome to [submit projects to this list](h
 * [nvim-dvc](https://github.com/gennaro-tedesco/nvim-dvc): Neovim plugin for DVC.
 * [COVID Genomics/Airflow-DVC](https://github.com/covid-genomics/airflow-dvc): Airflow extension for DVC.
 * [COVID Genomics/dvc-fs](https://github.com/covid-genomics/dvc-fs): High-level abstraction for DVC file manipulation (listing & I/O) with basic support for [PyFilesystem2](https://github.com/PyFilesystem/pyfilesystem2).
+* [ZnTrack](https://github.com/zincware/ZnTrack): Object-Relational Mapping for https://dvc.org in Python.
 
 ## Tutorials
 * [DVC Streamlit Example](https://github.com/sicara/dvc-streamlit-example): Build a custom web UI with DVC and Streamlit for visually tracking & comparing model performance during R&D (adapted from [TensorFlow's transfer learning tutorial](https://www.tensorflow.org/tutorials/images/transfer_learning)).


### PR DESCRIPTION
The ZnTrack package `pip install zntrack` allows to build DVC Stages directly within Python.
It supports all options, such as `outs, outs-no-cache, ...` and extends them by some ZnTrack specific ones `zn.outs, zn.metrics` that do not required to define an output file.

A Node on the DAG can be defined via a Python class:



```py
from zntrack import Node, dvc, zn
import random

@Node()
class HelloWorld:
    maximum = dvc.params()
    random_number = zn.outs()
    
    def __call__(self, maximum):
        self.maximum = maximum
        
    def run(self):
        self.random_number = random.randrange(self.maximum)
```

Calling the Node will run the `dvc run` command in the background for us.

```py
hello_world = HelloWorld()

hello_world(25) # this will write the dvc.yaml and params.yaml
```

After `dvc repro` we can access the results:

```py
print(HelloWorld(load=True).maximum) # will print 25
print(HelloWorld(load=True).random_numer)
```

We can expand the graph by adding more nodes and connecting them via `dvc.deps`. Add some metrics and outfiles as further examples

```py
from pathlib import Path

@Node()
class SquareNumber:
    hello_world: HelloWorld = dvc.deps(HelloWorld(load=True))
    some_metric = zn.metrics()
    outfile: Path = dvc.outs(Path("metrics.json"))
    
    def run(self):
        self.some_metric = {"maximum": self.hello_world.random_number ** 2}
        self.outfile.write_text("Lorem Ipsum")

SquareNumber()()
# then dvc repro
print(SquareNumber(load=True).outfile) # Path("metrics.json")
# dvc metrics show will show the metrics
```

It also has an experimental feature that allows defining the Nodes in a Jupyter Notebook.
In my experience, ZnTrack makes using DVC more pythonic and decreases the learning curve for new users familiar with Python.

This is only a brief overview of the core features and for more information check out https://zntrack.readthedocs.io/en/latest/ , put up an issue or ask me directly.